### PR TITLE
Changes to input command

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,19 +551,18 @@ Input a number - 22
 
 Multiple items may be input by supplying a comma separated list. Input variables will be assigned
 to as many input values as supplied at run time. If there are more input values supplied than input
-variables, the excess input values will be ignored. Conversely, if not enough input values are
+variables, excess commas will be left in place. Conversely, if not enough input values are
 supplied, then the excess input variables will not be initialised (and will trigger an error if
 an attempt is made to evaluate those variables later in the program).
 
-Further, numeric input values must be valid numbers (integers or floating point), and must
-be unquoted. String input values must be surrounded by double quotes:
+Further, numeric input values must be valid numbers (integers or floating point).
 
 ```
 > 10 INPUT "Num, Str, Num: ": A, B$, C
 > 20 PRINT A, B$, C
 > RUN
-Num, Str, Num: 22, " hello ", 33
-22 hello 33
+Num, Str, Num: 22, hello!, 33
+22 hello!33
 >
 ```
 

--- a/basicparser.py
+++ b/basicparser.py
@@ -419,6 +419,9 @@ class BASICParser:
         # Acquire the comma separated input variables
         variables = []
         if not self.__tokenindex >= len(self.__tokenlist):
+            if self.__token.category != Token.NAME:
+                raise ValueError('Expecting NAME in INPUT statement ' +
+                                 'in line ' + str(self.__line_number))
             variables.append(self.__token.lexeme)
             self.__advance()  # Advance past variable
 
@@ -428,7 +431,7 @@ class BASICParser:
                 self.__advance()  # Advance past variable
 
         # Gather input from the user into the variables
-        inputvals = input(prompt).split(',')
+        inputvals = input(prompt).split(',', (len(variables)-1))
 
         for variable in variables:
             left = variable
@@ -437,16 +440,7 @@ class BASICParser:
                 right = inputvals.pop(0)
 
                 if left.endswith('$'):
-                    # Python inserts quotes around input data
-                    if not right.find('"') == 1 and \
-                       not right.find('"', 2):
-                        raise ValueError('Non-string input provided to a string variable ' +
-                                         'in line ' + str(self.__line_number))
-
-                    else:
-                        # Strip the quotes from the stored string
-                        stripped = right.strip()  # May be space before or after quotes
-                        self.__symbol_table[left] = stripped.replace('"', '')
+                    self.__symbol_table[left] = str(right)
 
                 elif not left.endswith('$'):
                     try:


### PR DESCRIPTION
To address 3 points:

1. The documentation specifies that strings must be in quotes but this is NOT the case. And because the code expects it you can get unusual results:
```
> 10 input a, b$, c
> 20 print a, b$, c
> run
? 1,bob,2
1bob2
> run
? 1,I'm "some "text",1
1I'm some text1
>
```

I have fixed this by formalising the current behaviour and allowing unquoted strings. A comment suggested python would add quotes automatically, but I couldn't get that to happen.

2. It's annoying you can't collect strings with commas. Since input assumes you are entering a list of values. I fixed this by only splitting the input string n times, where n is the number of input variables.

3. Now throws an error when the inputs aren't NAMEs.