### PR TITLE
Switch load/save to text listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A program is executed using the **RUN** command:
 >
 ```
 
-A program may be saved to disk using the **SAVE** command. Not that the full path must be specified within double quotes:
+A program may be saved to disk using the **SAVE** command. Note that the full path must be specified within double quotes:
 
 ```
 > SAVE "C:\path\to\my\file"
@@ -80,10 +80,7 @@ Program written to file
 >
 ```
 
-Saving is achieved by pickling the Python object that represents the BASIC program, i.e. the saved file is *not* a textual copy of
-the program statements.
-
-The program may be re-loaded (i.e. unpickled) from disk using the **LOAD** command, again specifying the full path using double quotes:
+The program may be re-loaded from disk using the **LOAD** command, again specifying the full path using double quotes:
 
 ```
 > LOAD "C:\path\to\my\file"
@@ -91,8 +88,11 @@ Program read from file
 >
 ```
 
-Since loading is performed by unpickling the program object from a file, only BASIC programs *previously saved
-by the interpreter* may be loaded.
+When loading or saving, the .bas extension is assumed if not provided.  If you are loading a simple name (alpha/numbers only) and in the working dir, quotes can be omitted:
+```
+> LOAD regression
+```
+Will load REGRESSION.bas from the current working directory.
 
 Individual program statements may be deleted by entering their line number only:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ When loading or saving, the .bas extension is assumed if not provided.  If you a
 ```
 > LOAD regression
 ```
-Will load REGRESSION.bas from the current working directory.
+Will load regression.bas from the current working directory.
 
 Individual program statements may be deleted by entering their line number only:
 

--- a/program.py
+++ b/program.py
@@ -71,8 +71,10 @@ class Program:
                      appended
 
         """
+        if not file.lower().endswith(".bas"):
+            file += ".bas"
         try:
-            with open(file + ".bas", "w") as outfile:
+            with open(file, "w") as outfile:
                 outfile.write(str(self))
         except OSError:
             raise OSError("Could not save to file")
@@ -87,9 +89,11 @@ class Program:
 
         # New out the program
         self.delete()
+        if not file.lower().endswith(".bas"):
+            file += ".bas"
         try:
             lexer = Lexer()
-            with open(file + ".bas", "r") as infile:
+            with open(file, "r") as infile:
                 for line in infile:
                     line = line.replace("\r", "").replace("\n", "").strip()
                     tokenlist = lexer.tokenize(line)

--- a/program.py
+++ b/program.py
@@ -41,23 +41,28 @@ class Program:
         # and loop returns
         self.__return_stack = []
 
-    def list(self):
-        """Lists the program"""
+    def __str__(self):
+
+        program_text = ""
         line_numbers = self.line_numbers()
 
         for line_number in line_numbers:
-            print(line_number, end=' ')
+            program_text += str(line_number) + " "
 
             statement = self.__program[line_number]
             for token in statement:
                 # Add in quotes for strings
                 if token.category == Token.STRING:
-                    print('"' + token.lexeme + '"', end=' ')
+                    program_text += '"' + token.lexeme + '" '
 
                 else:
-                    print(token.lexeme, end=' ')
+                    program_text += token.lexeme + " "
+            program_text += "\n"
+        return program_text
 
-            print(flush=True)
+    def list(self):
+        """Lists the program"""
+        print(str(self), end="")
 
     def save(self, file):
         """Save the program
@@ -68,26 +73,7 @@ class Program:
         """
         try:
             with open(file + ".bas", "w") as outfile:
-                line_numbers = self.line_numbers()
-
-                for line_number in line_numbers:
-                    outfile.write(str(line_number) + " ")
-
-                    statement = self.__program[line_number]
-                    for i in range(len(statement)):
-                        token = statement[i]
-                        # Add in quotes for strings
-                        if token.category == Token.STRING:
-                            outfile.write('"' + token.lexeme + '"')
-
-                        else:
-                            outfile.write(token.lexeme)
-
-                        if i + 1 < len(statement):
-                            outfile.write(" ")
-
-                    outfile.write("\n")
-                outfile.close()
+                outfile.write(str(self))
         except OSError:
             raise OSError("Could not save to file")
 
@@ -108,7 +94,6 @@ class Program:
                     line = line.replace("\r", "").replace("\n", "").strip()
                     tokenlist = lexer.tokenize(line)
                     self.add_stmt(tokenlist)
-                infile.close()
 
         except OSError:
             raise OSError("Could not read file")


### PR DESCRIPTION
Hi Hi!

Thank you so much for making the basic interpreter in Python available.  I've been playing around with it via CircuitPython as the basis for a sort of retro handheld that boots to a basic interpreter. 

Not sure if you want to accept random PR's, but allowing the loading/saving of ascii program listings was one of my first mods so that I could load some of the online vintage basic goodness.  Typing listings in definitely brings back good memories, but it turns out I'm a bit less patient than I was as a youngster :-)

