### PR TITLE
Add logic to ignore everything on REM statement

### DIFF
--- a/lexer.py
+++ b/lexer.py
@@ -56,9 +56,6 @@ class Lexer:
         # Establish a list of tokens to be
         # derived from the statement
         tokenlist = []
-        firstToken = False
-        firstNumber = True
-        commentStmt = False
 
         # Process every character until we
         # reach the end of the statement string
@@ -73,22 +70,9 @@ class Lexer:
             # incremented
             token = Token(self.__column - 1, None, '')
 
-            # Remark Statments - process rest of statement without checks
-            if commentStmt:
-                token.category = Token.REM
-                firstToken = False
-
-                while True:
-                    token.lexeme += c  # Append the current char to the lexeme
-                    c = self.__get_next_char()
-
-                    if c == '':
-                        break
-
             # Process strings
-            elif c == '"':
+            if c == '"':
                 token.category = Token.STRING
-                firstToken = False
 
                 # Consume all of the characters
                 # until we reach the terminating
@@ -118,9 +102,6 @@ class Lexer:
             elif c.isdigit():
                 token.category = Token.UNSIGNEDINT
                 found_point = False
-                if firstNumber:
-                    firstToken = True
-                firstNumber = False
 
                 # Consume all of the digits, including any decimal point
                 while True:
@@ -162,17 +143,20 @@ class Lexer:
                 if token.lexeme in Token.keywords:
                     token.category = Token.keywords[token.lexeme]
 
-                    if firstToken and token.lexeme == "REM":
-                        commentStmt = True
-                    firstToken = False
-
                 else:
                     token.category = Token.NAME
-                    firstToken = False
+
+                # Remark Statments - process rest of statement without checks
+                if token.lexeme == "REM":
+                    token.lexeme += c
+                    c = self.__get_next_char()
+
+                    while c!= '':
+                        token.lexeme += c  # Append the current char to the lexeme
+                        c = self.__get_next_char()
 
             # Process operator symbols
             elif c in Token.smalltokens:
-                firstToken = False
                 save = c
                 c = self.__get_next_char()  # c might be '' (end of stmt)
                 twochar = save + c

--- a/lexer.py
+++ b/lexer.py
@@ -148,9 +148,6 @@ class Lexer:
 
                 # Remark Statments - process rest of statement without checks
                 if token.lexeme == "REM":
-                    token.lexeme += c
-                    c = self.__get_next_char()
-
                     while c!= '':
                         token.lexeme += c  # Append the current char to the lexeme
                         c = self.__get_next_char()


### PR DESCRIPTION
This change will prevent mismatched quotes or unrecognized tokens on a REM statement from generating Syntax Errors