### PR TITLE
Tab() behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ at position *start* and end at *end*. Returns 0 if no match found.
 
 * **VAL**(x$) - Attempts to convert *x$* to a numeric value. If *x$* is not numeric, returns 0.
 
-* **TAB**(x) - Generates a string containing x spaces with no CR/LF
+* **TAB**(x) - A special function with predictable results only when used as an argument to a **PRINT** statment. The **TAB** function specifies the position on the line where the next text is printed. If the specified position is less than the current print position a newline is printed and the print location is set to the specified column.
 
 **NOTE** For compatibility with older basic dialetcs, all string indexes are 1 based.
 

--- a/basicparser.py
+++ b/basicparser.py
@@ -286,7 +286,10 @@ class BASICParser:
 
             if type(self.__operand_stack[-1]) == tuple and self.__operand_stack[-1][0] == "TAB":
                 if self.__prnt_column > self.__operand_stack[-1][1]:
-                    print()
+                    if fileIO:
+                        self.__file_handles[filenum].write("\n")
+                    else:
+                        print()
                     self.__prnt_column = 0
 
                 current_pr_column = self.__operand_stack[-1][1] - self.__prnt_column

--- a/examples/regression.bas
+++ b/examples/regression.bas
@@ -91,6 +91,8 @@
 1010 READ I , J , K , L 
 1020 PRINT "the next line should print 4561.5:" 
 1030 PRINT I; J ; K ; L 
+1040 PRINT "The next lines should print: 'Hello World' and then 'AGAIN' under the word 'World'"
+1050 PRINT "Hel" ; : PRINT "lo" ; TAB ( 7 ) ; "World" ; TAB ( 7 ) ; "AGAIN" 
 1610 PRINT "*** Finished ***"
 1620 STOP
 1630 REM A SUBROUTINE TEST


### PR DESCRIPTION
Changes the behavior of the Tab function to place the cursor at the specified column rather than returning a string of the specified number of spaces. 

After this update if the Tab function is used in an assignment to a string variable an error will be displayed. Oddly enough, if an integer variable is assigned the tab function the variable will receive a python Tuple which can't really be used by BASIC, however if the integer variable is printed it will be treated as though the original tab was printed.