### PR TITLE
GitHub Action to run pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,11 @@
+name: pytest
+on: [pull_request, push]
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: pip install pytest
+      - run: pytest --doctest-modules .

--- a/flowsignal.py
+++ b/flowsignal.py
@@ -22,11 +22,11 @@ return address need to be added to the return stack.
 
 >>> flowsignal = FlowSignal(ftype=FlowSignal.RETURN)
 >>> print(flowsignal.ftarget)
--1
+None
 >>> flowsignal = FlowSignal(ftarget=100, ftype=FlowSignal.SIMPLE_JUMP)
->>> print(flowsignal.ftarget)
+>>> flowsignal.ftarget
 100
->>> print(flowsignal.ftype)
+>>> flowsignal.ftype
 0
 """
 


### PR DESCRIPTION
Based on the feedback at https://github.com/richpl/PyBasic/pull/57#issuecomment-962672683, a GitHub Action that ___only runs pytest___.  https://docs.pytest.org

Test results: https://github.com/cclauss/PyBasic/actions

Fixes a failing doctest: `FlowSignal(ftype=FlowSignal.RETURN).ftarget`  is `None`, not `-1`

$ `pytest --doctest-modules .`
```
============================= test session starts ==============================
platform linux -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/runner/work/PyBasic/PyBasic
collected 2 items

flowsignal.py .                                                          [ 50%]
lexer.py .                                                               [100%]

============================== 2 passed in 0.07s ===============================
```