### PR TITLE
count linux/windows newline chars properly when opening files for append

### DIFF
--- a/basicparser.py
+++ b/basicparser.py
@@ -673,10 +673,29 @@ class BASICParser:
                 raise RuntimeError('File '+filename+' could not be opened in line ' + str(self.__line_number))
 
         if accessMode == "r+":
+            # By checking the 'newlines' attribute the appropriate adjustment for
+            # the file being opened can be determined.
+            if hasattr(self.__file_handles[filenum],'newlines'):
+                try:
+                    # newline attribute is only set after a line is read
+                    self.__file_handles[filenum].readline()
+                except:
+                    pass
+                newlines = self.__file_handles[filenum].newlines
+            else:
+                newlines = None
+            
             self.__file_handles[filenum].seek(0)
             filelen = 0
+            if newlines != None:
+                newlineAdj = len(newlines) - 1
+            else:
+                # If using version of Python that doesn't have newlines attribute
+                # use adjustment appropriate for Windows formatted files
+                newlineAdj = 1
+
             for lines in self.__file_handles[filenum]:
-                filelen += len(lines)+1
+                filelen += len(lines)+newlineAdj
 
             self.__file_handles[filenum].seek(filelen)
 

--- a/examples/regression.bas
+++ b/examples/regression.bas
@@ -57,8 +57,22 @@
 570 PRINT "The next line should say 'Hello World!'"
 580 FSEEK #2,10
 590 INPUT #2,A$
-600 PRINT A$
-610 OPEN "NOFILE.X7Z" FOR INPUT AS #2 ELSE 620
+595 PRINT A$
+600 CLOSE #2
+601 OPEN "REGRESSION.TXT" FOR APPEND AS #2
+602 PRINT "3 text lines starting with 0,T,S and ending with !,g,e should follow:"
+603 PRINT #2,"Should be a seperate line"
+604 CLOSE #2
+605 OPEN "REGRESSION.TXT" FOR INPUT AS #2
+606 FOR I = 1 TO 2
+607 INPUT #2,A$:PRINT A$
+608 NEXT I
+609 INPUT #2,A$
+610 FOR I = 1 TO 25
+611 PRINT MID$(A$,I,1);
+612 NEXT I
+613 PRINT:CLOSE #2
+614 OPEN "NOFILE.X7Z" FOR INPUT AS #2 ELSE 620
 615 PRINT "***This Message should NOT be Displayed***"
 620 N = 0
 630 I = 7


### PR DESCRIPTION
Windows by default uses 2 bytes for the newline character while Linux typically uses 1. The Windows two-byte newline character only adds a single byte to length within python when readline is used, but two bytes are used in the file so an adjustment needs to be done when tracking the file position. To complicate things further, files transferred between Windows and Linux may use the other platforms newline character. This PR uses the python file.newlines method to determine which new line method is being used on the file being opened.

I tested on a Linux system and here is the regression.bas output after this fix is applied. I've also included the "file i/o" section that demonstrates the error as the third displayed line is missing the last two characters.
```
> load "examples/regression.bas"
Program read from file
> run
*** Testing basic arithmetic functions and multiple statements ***
Expecting the sum to be 300:
300
Expecting the product to be 20000:
20000
Expecting the sum to be 20100:
20100
Expecting sum to be 40000
40000
Should print the larger value of J which is 200
200
*** Testing subroutine behaviour ***
Calling subroutine
Executing the subroutine
Exited subroutine
Now testing nested subroutines
This should be printed first
This should be printed second
*** Testing loops ***
This loop should count to 5 in increments of 1:
1
2
3
4
5
This loop should count back from 10 to 1 in decrements of 2:
10
8
6
4
2
These nested loops should print 11, 12, 13, 21, 22, 23:
11
12
13
21
22
23
*** Testing arrays ***
This should print 555
555
*** Testing file i/o ***
The next line should say 'Hello World!'
Hello World!
3 text lines starting with 0,T,S and ending with !,g,e should follow:
0123456789Hello World!
This is second line for testing
Should be a seperate line
This loop should count to 5 in increments of 1 twice:
1
2
3
4
5
1
2
3
4
5
The loop variable I should be equal to 5, I=5
The next line should read: DATA Statement tests...
DATA Statement tests...
The next three lines should be: 12 34 56
12
34
56
the next line should print 123
123
Float: 1.5 Int: 2 String: test
the next line should print 4561.5:
4561.5
The next lines should print: 'Hello World' and then 'AGAIN' under the word 'World'
Hello World
      AGAIN
This loop should count from 1 to 10
1
2
3
4
5
6
7
8
9
10
Enter T for the THEN blocks to execute, E for the ELSE (T/E): t
1190: Entered T
1230: Entered T
1280: Entered T
1330: Entered T
1340: Entered T
1360: Entered T
1370: Entered T
1390: Entered T
1400: Entered T
1410: Entered T
Compound Stmt w/conditionals 1420: Entered T
*** Finished ***
> 
```

Pre-Fix regression.bas output:
```
*** Testing file i/o ***
The next line should say 'Hello World!'
Hello World!
3 text lines starting with 0,T,S and ending with !,g,e should follow:
0123456789Hello World!
This is second line for testing
Should be a seperate li
This loop should count to 5 in increments of 1 twice:
1
2
3
4
5
1
2
3
4
5
```