### PR TITLE
Fixed parsing float when first character is point:

### DIFF
--- a/lexer.py
+++ b/lexer.py
@@ -99,9 +99,12 @@ class Lexer:
                             break
 
             # Process numbers
-            elif c.isdigit():
+            elif c.isdigit() or c == '.':
                 token.category = Token.UNSIGNEDINT
                 found_point = False
+                if c == '.':
+                    token.category = Token.UNSIGNEDFLOAT
+                    found_point = True
 
                 # Consume all of the digits, including any decimal point
                 while True:
@@ -112,7 +115,7 @@ class Lexer:
                     # and this is not the first decimal point
                     if not c.isdigit():
                         if c == '.':
-                            if not found_point:
+                            if found_point is False:
                                 found_point = True
                                 token.category = Token.UNSIGNEDFLOAT
 


### PR DESCRIPTION

I am working on creating a parser for old Z80 basic code.  I need the ability to  have floats that start with the decimal point.  I notice in your docs yours does not.  I thought I would send this pull request incase removing that limitation is desired.   

Example of one that does not work before this commit:

10 a=.5
20 print "a should be ";.5;" look a is ";a