### PR TITLE
update garbage collection info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,7 @@ Empty array value returned in line 30
 >
 ```
 
-As in all implementations of BASIC, there is no garbage collection (not surprising since all variables
-have global scope)!
+Since **all PyBasic variables have a global scope** and string memory is managed by the python interpreter, there is no garbage collection in PyBasic.  
 
 ### Program constants
 


### PR DESCRIPTION
fixes #79 

I was surprised to find that early versions of Basic did actually perform garbage collection, even in versions that only supported global variables. Apparently dynamic string memory management required it.

Anyway, I think this update to the README should now be factually correct and still convey the info that variables in Pybasic have a global scope.

By the way, did you see that the new [Fruit Jam OS](https://learn.adafruit.com/fruit-jam-os/apps) includes PyBasic as a bundled app? :grin: