### PR TITLE
make platform 'newlines' identification more robust

### DIFF
--- a/basicparser.py
+++ b/basicparser.py
@@ -666,22 +666,30 @@ class BASICParser:
         if accessMode == "r+":
             # By checking the 'newlines' attribute the appropriate adjustment for
             # the file being opened can be determined.
-            if hasattr(self.__file_handles[filenum],'newlines'):
-                try:
-                    # newline attribute is only set after a line is read
-                    self.__file_handles[filenum].readline()
-                except:
-                    pass
-                newlines = self.__file_handles[filenum].newlines
-            else:
+
+            try:
+                # newline attribute is only set after a line is read
+                # manually identify newlines in case newlines attribute isn't supported
+                fileline = self.__file_handles[filenum].readline()
+                newlines = ""
+                for ichar in range(len(fileline)-1,-1,-1):
+                    if fileline[ichar] not in ['\n','\r']:
+                        break
+                    newlines = fileline[ichar:]
+            except:
                 newlines = None
-            
+
+            if hasattr(self.__file_handles[filenum],'newlines'):
+                newlines = self.__file_handles[filenum].newlines
+
             self.__file_handles[filenum].seek(0)
             filelen = 0
-            if newlines != None:
+
+            if newlines is not None:
                 newlineAdj = len(newlines) - 1
             else:
-                # If using version of Python that doesn't have newlines attribute
+                # If we wern't able to determine an appropriate value and
+                # using version of Python that doesn't have newlines attribute
                 # use adjustment appropriate for Windows formatted files
                 newlineAdj = 1
 


### PR DESCRIPTION
While playing around with and testing the new WHILE statements on CircuitPython, I noticed while running regression.bas that the OPEN for APPEND statement wasn't calculating the end of file correctly.

Python running on Windows and Linux file system handle newline characters differently requiring different methods to calculate how many bytes a line of text takes up in a text file. PyBasic is using the newlines file handle attribute which was supposed to properly adjust the line length calculation for the platform being used, however apparently CircuitPython has not implemented the newlines attribute and the code fell back to using the Windows calculation which is wrong for CircuitPython.

This update adds a manual check for newline characters if the newlines attribute doesn't exist so that the calculation can be properly performed on platforms that don't support the newlines attribute. 

I've tested on Linux, Windows and CircuitPython and the new code now properly runs the entire regression suite on all three platforms.